### PR TITLE
Added Copper Bonsai Trees Compat

### DIFF
--- a/src/main/resources/data/bonsaitrees3/recipes/sapling/ore_tree/copper_s.json
+++ b/src/main/resources/data/bonsaitrees3/recipes/sapling/ore_tree/copper_s.json
@@ -1,0 +1,27 @@
+{
+  "type": "bonsaitrees3:sapling",
+  "mod": "ore_tree",
+  "sapling": {
+    "item": "ore_tree:copper_tree_sapling"
+  },
+  "drops": [
+    {
+      "rolls": 5,
+      "chance": 1,
+      "result": {
+        "item": "ore_tree:copper_tree_log"
+      }
+    },
+    {
+      "rolls": 2,
+      "chance": 0.3,
+      "result": {
+        "item": "minecraft:oak_leaves"
+      },
+      "requiresSilkTouch": true
+    }
+  ],
+  "compatibleSoilTags": [
+    "copper_tree"
+  ]
+}

--- a/src/main/resources/data/bonsaitrees3/recipes/soil/ore_tree/copper.json
+++ b/src/main/resources/data/bonsaitrees3/recipes/soil/ore_tree/copper.json
@@ -1,0 +1,14 @@
+{
+  "type": "bonsaitrees3:soil",
+  "mod": "ore_tree",
+  "tickModifier": 300,
+  "soil": {
+    "item": "minecraft:copper_ore"
+  },
+  "compatibleSoilTags": [
+    "copper_tree"
+  ],
+  "display": {
+    "block": "minecraft:copper_ore"
+  }
+}

--- a/src/main/resources/data/bonsaitrees3/recipes/soil/ore_tree/copper_d.json
+++ b/src/main/resources/data/bonsaitrees3/recipes/soil/ore_tree/copper_d.json
@@ -1,0 +1,14 @@
+{
+  "type": "bonsaitrees3:soil",
+  "mod": "ore_tree",
+  "tickModifier": 300,
+  "soil": {
+    "item": "minecraft:deepslate_copper_ore"
+  },
+  "compatibleSoilTags": [
+    "copper_tree"
+  ],
+  "display": {
+    "block": "minecraft:deepslate_copper_ore"
+  }
+}


### PR DESCRIPTION
Added in copper tree sapling as an option for bonsai trees.
Added in copper ore and deepslate copper ore as soils.
I went with 300 Tick Modifier to try and balance between coal and iron.